### PR TITLE
Add junow/boj/1543

### DIFF
--- a/problems/boj/1543/junow.cpp
+++ b/problems/boj/1543/junow.cpp
@@ -1,0 +1,29 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+string s, t;
+int i, sLen, tLen, ans;
+
+int main(void)
+{
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  getline(cin, s);
+  getline(cin, t);
+  i = 0;
+  sLen = s.size();
+  tLen = t.size();
+  ans = 0;
+  while (i < sLen)
+  {
+    int ni = s.find(t, i);
+    if (ni < 0)
+      break;
+    i = ni + tLen;
+    ans++;
+  }
+  cout << ans;
+  return 0;
+}


### PR DESCRIPTION
# 1543. 문서 검색

[문제링크](https://www.acmicpc.net/problem/1543)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver IV |   32.354%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |     0     |

## 설계

- 공백까지 문자열로 받기 위해서는 getline() 함수 이용

1. 문서는 s , 검색할 단어는 t
2. string 의 find 함수를 이용한다. (두번째 인자는 검색시작할 위치)
3. 인덱스 i 를 두고 s.find(t,i) 로 단어가 있는 위치를
   - 음수가 나온다면 `break`
   - 양수가 나온다면 `t` 의 길이만큼 `i+=t` (검색된 index 건너뛰기 위해)
4. `ans++`;
5. 3 번부터 반복

### 시간복잡도

### 공간복잡도
