### PR TITLE
ADd junow boj 2812 크게 만들기

### DIFF
--- a/problems/boj/2812/junow.cpp
+++ b/problems/boj/2812/junow.cpp
@@ -1,0 +1,32 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+int N, K;
+string num;
+
+int main(void) {
+  ios::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> N >> K >> num;
+
+  int i = 0;
+  int len = num.size();
+  int cnt = 0;
+  vector<char> ans;
+
+  for (int i = 0; i < len; i++) {
+    while (cnt < K && ans.size() > 0 && ans.back() < num[i]) {
+      ans.pop_back();
+      cnt++;
+    }
+    ans.push_back(num[i]);
+  }
+
+  int ansLen = ans.size();
+  for (int i = 0; i < ansLen - (K - cnt); i++) {
+    cout << ans[i];
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# 문제번호. 문제제목

[문제링크](https://www.acmicpc.net/problem/2812)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| Gold V |   22.478%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    3652     |    12     |

## 설계

- 각 자리 숫자들을 보면서 가장 이수를 크게 만들 수 잇는 자리수로 찾아가게한다.
- 자리를 바꿀 수 없기때문에 조건이 안되면 ans vector 에 그냥 push 한다.

1. 각 자리수의 숫자들을 순회한다.
2. 이 수가 들어갈 수 있는 제일 높은 자리수까지 올린다.
   - 한번 올릴때마다 cnt 가 증가.
3. cnt를 K 만큼 쓰지 않았다면 조건에 맞은 적이 없으니까 K 보다적은거니까 조건에 안맞는 숫자들이 ans vector 에 들어갔을것. 얘네들은 자르고 출력.

### 시간복잡도

- N \* N/2 + N

### 공간복잡도

### https://www.acmicpc.net/source/9392295

이분처럼 벡터 안쓰고 하면 같은 로직으로도 4ms 이 나온다.
