### PR TITLE
Add junow boj 2012

### DIFF
--- a/problems/boj/2012/junow.cpp
+++ b/problems/boj/2012/junow.cpp
@@ -1,0 +1,25 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+int N;
+int arr[500000];
+
+int main(void) {
+  ios::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> N;
+
+  for (int i = 0; i < N; i++) {
+    cin >> arr[i];
+  }
+
+  sort(arr, arr + N);
+
+  long long ans = 0;
+  for (int i = 0; i < N; i++) {
+    ans += abs(arr[i] - (i + 1));
+  }
+  cout << ans << "\n";
+  return 0;
+}


### PR DESCRIPTION
# 2012. 등수 매기기

[문제링크](https://www.acmicpc.net/problem/2012)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   38.286%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    3936     |    84     |

## 설계

그냥 정렬하였음

원하는 순위가 2,2,3,3,4,4 일때

불만족도를 가장 낮게 만드는 건 어떻게 해도 그냥 가장 비슷한 자리에 두는 것임.

ex) 4등을 2등으로 만들어봤자 불만족도는 늘어나기만 할뿐, 아무런 이득이 없음.

정답은 int 범위를 벗어날 수 있으니 주의해야함;

### 시간복잡도

정렬 - NlogN
불만족도 구하기 - N

### 공간복잡도
