### PR TITLE
Add junow boj 3109 빵집

### DIFF
--- a/problems/boj/3109/junow.cpp
+++ b/problems/boj/3109/junow.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+
+using namespace std;
+
+const int dy[3] = {-1, 0, 1};
+const int dx[3] = {1, 1, 1};
+
+int r, c, ans;
+char board[10000][500];
+char ch;
+
+bool bfs(int y, int x) {
+  if (x == c - 1) return true;
+  for (int dir = 0; dir < 3; dir++) {
+    int ny = y + dy[dir];
+    int nx = x + dx[dir];
+
+    if (ny >= r || ny < 0 || nx >= c || nx < 0) continue;
+    if (board[ny][nx] == 'x') continue;
+
+    board[ny][nx] = 'x';
+    if (bfs(ny, nx)) return true;
+  }
+  return false;
+}
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> r >> c;
+
+  for (int i = 0; i < r; i++) {
+    cin >> board[i];
+  }
+
+  for (int i = 0; i < r; i++) {
+    if (bfs(i, 0)) ans++;
+  }
+
+  cout << ans << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 3109. 빵집

[문제링크](https://www.acmicpc.net/problem/3109)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold II |   27.613%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    6868     |    56     |

## 설계

이게 왜 그리디인지는 모르겠지만 그냥 bfs 로 풀었습니다.

가야하는 방향은 왼쪽으로 갈일은 없어서 오른쪽위, 오른쪽, 오른쪽 아래입니다.

일반적인 q 를 이용한 bfs 로는 끝점에 도달하자 마자 다 취소하는 로직을 잘 못짜겠어서 재귀형식으로 끝에 도달하면 다 취소하는 식으로 구현했습니다.

입력이 다음처럼 한줄로 들어오는 경우 한줄씩 받는게 이중포문으로 받는것보다 두배나 빠르더군요 조심해야겠습니다.

```c
/**
  5 5
  .xx..
  ..x..
  .....
  ...x.
  ...x.
*/
for(int i=0;i<r;i++){
  cin>>board[i];
}

```


### 시간복잡도

O(N\*M)

### 공간복잡도
