### PR TITLE
bbumjun boj 2262 토너먼트 만들기

### DIFF
--- a/problems/boj/2262/bbumjun.py
+++ b/problems/boj/2262/bbumjun.py
@@ -1,0 +1,12 @@
+n = int(input())
+nodes = list(map(int, input().split()))
+
+answer = 0
+while len(nodes) > 1:
+    winners = []
+    for i in range(len(nodes)-1):
+        winners.append((min(nodes[i], nodes[i+1]), max(nodes[i], nodes[i+1])))
+    winner, loser = max(winners)
+    answer += abs(winner-loser)
+    nodes.remove(loser)
+print(answer)


### PR DESCRIPTION
# 2262. 토너먼트 만들기

[문제링크](https://www.acmicpc.net/problem/2262)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver I |   49.801%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   121968    |    164    |

## 설계

처음에는 대진표에서 순위 차이가 가장 작은 2명이 차례대로 시합을 하는 방식으로 로직을 짰지만 다른 반례에 막혔다.

반례에 따라서 찾은 로직은 대진표에서 일어날 수 있는 시합중 승리자의 순위가 가장 낮은 시합을 먼저 열여야 한다는 것이었다.

1. 현재 라운드에서 일어날 수 있는 모든 시합의 승리자와 패배자를 list에 담는다.
2. 승리자들 중 가장 순위가 낮은 승리자가 있는 시합의 차잇값을 answer에 더한다.
3. 해당 시합의 패배자를 대진표 list 에서 제거한다.
4.  모든 선수가 제거 될 때 까지 1~3을 반복한다.

### 시간복잡도

O(N^2)