### PR TITLE
bbumjun boj 3109 빵집

### DIFF
--- a/problems/boj/3109/bbumjun.py
+++ b/problems/boj/3109/bbumjun.py
@@ -1,0 +1,36 @@
+r_size, c_size = map(int, input().split())
+field = [list(input()) for i in range(r_size)]
+answer = 0
+
+
+def isRange(a, b):
+    global r_size, c_size
+    if a < 0 or a >= r_size or b < 0 or b >= c_size:
+        return False
+    return True
+
+
+dirs = [(-1, 1), (0, 1), (1, 1)]
+
+
+def dfs(a, b):
+    global field, r_size, c_size, answer, dirs
+    stack = [(a, b)]
+    while len(stack) != 0:
+        r, c, = stack[-1]
+        if c == c_size-1:
+            answer += 1
+            return
+        field[r][c] = 'x'
+        for dir in dirs:
+            tr, tc = (r+dir[0], c+dir[1])
+            if isRange(tr, tc) is True and field[tr][tc] == '.':
+                stack.append((tr, tc))
+                break
+        else:
+            stack.pop()
+
+
+for i in range(r_size):
+    dfs(i, 0)
+print(answer)


### PR DESCRIPTION
# 3109. 빵집

[문제링크](https://www.acmicpc.net/problem/3109)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold II |   27.645%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   322848    |    924    |

## 설계

dfs를 통해 왼쪽 끝에서 오른쪽 끝을 탐색하도록 했다.

최대한 많이 설치해야 하기 때문에 dfs과정에서 윗방향을 먼저 탐색하도록 했다.

파이프를 연결 했을 때 바로 함수를 종료시키기 위해 재귀방식 대신 stack을 사용하여 dfs를 구현했다.

### 시간복잡도

O(N^2)