### PR TITLE
Add junow/boj/1202

### DIFF
--- a/problems/boj/1202/junow.cpp
+++ b/problems/boj/1202/junow.cpp
@@ -1,0 +1,48 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+const int MAX = 300000;
+int n, k, c[MAX];
+pair<int, int> a[MAX];
+priority_queue<int> pq;
+
+long long ans;
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> n >> k;
+  int t1, t2;
+  for (int i = 0; i < n; i++) {
+    cin >> t1 >> t2;
+    a[i] = {t1, t2};
+  }
+
+  for (int i = 0; i < k; i++) {
+    cin >> c[i];
+  }
+
+  sort(c, c + k);
+  sort(a, a + n);
+
+  int ji = 0;
+
+  for (int i = 0; i < k; i++) {
+    while (ji < n && a[ji].first <= c[i]) {
+      pq.push(a[ji].second);
+      ji++;
+    }
+
+    if (!pq.empty()) {
+      int maxValue = pq.top();
+      pq.pop();
+      ans += maxValue;
+    }
+  }
+
+  cout << ans << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 1202. 보석 도둑

[문제링크](https://www.acmicpc.net/problem/1202)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold II |   23.543%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    7168     |    160    |

## 설계

각 가방을 확인하면서 가능한 모든 보석들을 우선순위 큐에 넣어둔다.

우선순위 top 에 있는 보석이 현재 보고 있는 가방에 넣을 수 있는 보석중 제일 비싼 보석.

제일 비산 보석을 pop 한후 남아있는 보석들은 우선순위 큐에 남겨둬서 그다음 가방 확인에 써먹음으로써 그리디하게 풀 수 있다.

### 시간복잡도

O(NKlogN)

### 공간복잡도
