### PR TITLE
bbumjun boj 1202 보석도둑

### DIFF
--- a/problems/boj/1202/bbumjun.py
+++ b/problems/boj/1202/bbumjun.py
@@ -1,0 +1,25 @@
+from sys import stdin
+import heapq
+n, m = map(int, stdin.readline().split())
+jewels = []
+bags = []
+for i in range(n):
+    jewels.append(list(map(int, stdin.readline().split())))
+for i in range(m):
+    bags.append((int(stdin.readline())))
+jewels.sort(key=lambda item: item[1], reverse=True)
+for i in range(n):
+    jewels[i].insert(0, i)  # 가격 순위 매김
+jewels.sort(key=lambda item: item[1])  # 가벼운 기준으로 다시 정렬
+bags.sort()
+answer = 0
+pq = []
+idx = 0
+for i in range(m):
+    while idx < n and bags[i] >= jewels[idx][1]:
+        heapq.heappush(pq, (jewels[idx][0], jewels[idx][2]))
+        idx += 1
+    if len(pq) != 0:
+        answer += heapq.heappop(pq)[1]
+
+print(answer)


### PR DESCRIPTION
# 1202. 보석 도둑

[문제링크](https://www.acmicpc.net/problem/1202)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold II |   23.551%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   219880    |   1808    |

## 설계

로직이 떠오르지 않아 구글링을 통해 풀이법을 참고했다.ㅠㅠ

우선순위 큐를 사용해서 문제를 해결해야 한다.

백준 채점서버에서는 priority queue 모듈이 사용이 불가하기 때문에 같은 동작을 하는 heap queue 모듈을 사용했다.

1. 보석을 값어치가 비싼 순으로 정렬한 후, 값어치의 순위를 각 보석의 튜플 첫번째 인덱스에 삽입한다.
2. 보석을 무게가 가벼운 순서로 다시 정렬하고, 가방도 가벼운 순서로 정렬한다.
3. 가벼운 가방부터 차례대로 자신이 담을 수 있는 보석을 우선순위 큐에 집어 넣는다.
4. 더이상 집어넣을 수 있는 보석이 없을때 , 우선순위 큐에서 가장 값어치 있는 보석을 pop한다.
5. 모든 가방을 확인할 때까지 3~4를 반복한다.

### 시간복잡도

O(K * N * log N)

