### PR TITLE
bbumjun boj 1781 컵라면

### DIFF
--- a/problems/boj/1781/bbumjun.py
+++ b/problems/boj/1781/bbumjun.py
@@ -1,0 +1,21 @@
+from sys import stdin
+import heapq
+n = int(stdin.readline())
+problems = []
+for i in range(n):
+    problems.append(list(map(int, stdin.readline().split())))
+
+problems.sort(key=lambda problem: problem[1], reverse=True)
+for i in range(n):
+    problems[i].insert(0, i)
+problems.sort(key=lambda problem: problem[1], reverse=True)
+answer = 0
+pq = []
+idx = 0
+for i in range(n, 0, -1):
+    while idx < n and problems[idx][1] >= i:
+        heapq.heappush(pq, problems[idx])
+        idx += 1
+    if len(pq) != 0:
+        answer += heapq.heappop(pq)[2]
+print(answer)


### PR DESCRIPTION
# 1781. 컵라면

[문제링크](https://www.acmicpc.net/problem/1781)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| Gold I |   30.789%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   178544    |           |

## 설계

전에 풀었던 보석도둑과 같은 로직으로 풀었다.

늦은 시간일수록 데드라인이 짧은 문제를 풀 수 없다는 점에서 늦은 시간에서부터 문제를 고르도록 했다.

1. 각 문제를 problems 에 list로 입력받고, 받을수 있는 컵라면이 많은 순으로 정렬한다.
2. 각 problems의 list 맨 앞에 우선순위값을 index로 삽입하고, 데드라인이 긴 순으로 다시 정렬한다.
3. n초부터 1초까지 for 문을 돌면서, k초에서 풀 수 없는 문제가 나올 때 까지 우선순위 큐에 push한다.
4. 우선순위큐에서 pop해  k초가 해당 문제를 풀고 answer에 컵라면 갯수를 더한다.
5. for 문이 종료되면 정답을 출력한다.

### 시간복잡도

O(N)?

### 