### PR TITLE
bbumjun boj 2941 크로아티아 알파벳

### DIFF
--- a/problems/boj/2941/bbumjun.py
+++ b/problems/boj/2941/bbumjun.py
@@ -1,0 +1,8 @@
+croatiaC = ['c=', 'c-', 'dz=', 'd-', 'lj', 'nj', 's=', 'z=']
+s = input()
+ans = 0
+for c in croatiaC:
+    ans += s.count(c)
+    s = s.replace(c, ' ')
+s = s.replace(' ', '')
+print(ans + len(s))


### PR DESCRIPTION
# 2941. 크로아티아 알파벳

[문제링크](https://www.acmicpc.net/problem/2941)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver V |   45.998    |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   121804    |    144    |

## 설계

1. 정의된 크로아티아 알파벳을 croatiaC 리스트에 담아둔다.
2. croatiaC 의 각 문자를 방문하면서 전체 문자열 s에서 해당 문자를 카운트해 answer에 더하고, 찾은 문자열들은 공백 문자열로 replace한다.
3. answer과 남은 문자열의 길이를 더해 출력한다.



### 시간복잡도

O(N^2)