### PR TITLE
Add junow/boj/2941 크로아티아 알파벳

### DIFF
--- a/problems/boj/2941/junow.cpp
+++ b/problems/boj/2941/junow.cpp
@@ -1,0 +1,33 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int i, ans;
+string s, ss[8] = {"c=", "c-", "dz=", "d-", "lj", "nj", "s=", "z="};
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> s;
+  int len = s.size();
+
+  while (i < len) {
+    int idx = -1, j = 0;
+    for (; j < 8; j++) {
+      idx = s.find(ss[j], i);
+      if (idx < 0 || idx != i) continue;
+
+      ans++;
+      i = idx + ss[j].size();
+      break;
+    }
+    if (j == 8) {
+      ans++;
+      i++;
+    }
+  }
+
+  cout << ans << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 2941. 크로아티아 알파벳

[문제링크](https://www.acmicpc.net/problem/2941)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver V |   45.995%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1988     |     0     |

## 설계

스트링을 입력받고 크로아티아 문자를 검색해서 위치를 찾고 업다면 한칸 전진한다.

모든 경우를 다검사하기 때문에 N 개의 문자열 * N 번의 검색으로 O(N^2) 으로 비효율적인 검색이지만 입력값이 작기 때문에 시간내에 가능하다.

### 시간복잡도

O(N^2)

### 공간복잡도
