### PR TITLE
junow/boj/9935

### DIFF
--- a/problems/boj/9935/junow.cpp
+++ b/problems/boj/9935/junow.cpp
@@ -1,0 +1,45 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+string s, b;
+string f = "FRULA";
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> s >> b;
+  int i = 0;
+  int slen = s.size();
+  int blen = b.size();
+
+  string t = "";
+  for (int i = 0; i < slen; i++) {
+    t.push_back(s[i]);
+
+    if (t.back() == b[blen - 1]) {
+      bool flag = true;
+      int tlen = t.size();
+      for (int j = 0; j < blen; j++) {
+        if (t[tlen - j - 1] != b[blen - j - 1]) {
+          flag = false;
+          break;
+        }
+      }
+
+      if (flag) {
+        for (int j = 0; j < blen; j++) {
+          t.pop_back();
+        }
+      }
+    }
+  }
+
+  if (t.size() == 0) {
+    cout << f << "\n";
+  } else {
+    cout << t << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# 9935. 문자열 폭발

[문제링크](https://www.acmicpc.net/problem/9935)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold IV |   20.753%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    6020     |    12     |

## 설계

문자열을 t 에 추가하다가 폭탄에 마지막문자열과 일치하면 그 앞에 문자열들도 폭탄 문자열과 같은지 검사한다.
만약 폭탄 문자열과 모두 같다면 폭탄 문자열 길이만큼 t 에서 pop_back() 해준다.

### 시간복잡도

O(NM)

### 공간복잡도

O(2N)
