### PR TITLE
junow/boj/5525

### DIFF
--- a/problems/boj/5525/junow.cpp
+++ b/problems/boj/5525/junow.cpp
@@ -1,0 +1,30 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int n, m, ans, cnt;
+string s;
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> n >> m >> s;
+
+  for (int i = 0; i < m - 1; i++) {
+    if (s[i] == 'O' && s[i + 1] == 'I') {
+      if (cnt == n) {
+        ans++;
+        cnt--;
+      }
+
+    } else if (s[i] == 'I' && s[i + 1] == 'O') {
+      cnt++;
+    } else {
+      cnt = 0;
+    }
+  }
+
+  cout << ans << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 5525. IOIOI

[문제링크](https://www.acmicpc.net/problem/5525)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver II |   33.193%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    3640     |     8     |

## 설계

IOIOI... 를 찾으면서 겹쳐있는 경우도 있기 때문에 한글자씩 보면서

1. "IO" 인경우, cnt 를 증가시켜준다.

2. "OI" 인 경우 cnt 가 n 만큼 채워졌는지 확인, 맞으면 정답 +1 하고 cnt 는 하나 깎음, 다음 글자가 IO면은 cnt 가 다시 +1 되면서 겹쳐있는 IOIOI 를 찾을 수 있음.

3. "IO"도 "OI"도 아닌 경우는 cnt 를 0 으로 초기화

# 질문

같은 코드에서 위는 맞고 아래는 틀린데 무슨차이인지? 궁급합니다

```c
// 맞는 코드
if (s[i] == 'O' && s[i + 1] == 'I') {
  if (cnt == n) {
    ans++;
    cnt--;
  }
}

// 틀린코드
if (s[i] == 'O' && s[i + 1] == 'I' && cnt==n) {
  ans++;
  cnt--;
}
```

### 시간복잡도

O(N)

### 공간복잡도
