### PR TITLE
bbumjun programmers 64064 불량사용자

### DIFF
--- a/problems/programmers/64064/bbumjun.py
+++ b/problems/programmers/64064/bbumjun.py
@@ -1,0 +1,31 @@
+banLists = set([])
+
+
+def dfs(idx, restIds, banned_id, selectedIds):
+    global banLists
+    candidates = []
+    for id in restIds:
+        if len(id) == len(banned_id[idx]):
+            for i in range(len(id)):
+                if id[i] != banned_id[idx][i] and banned_id[idx][i] != '*':
+                    break
+            else:
+                candidates.append(id)
+    if idx == len(banned_id)-1:
+        for candidate in candidates:
+            lst = selectedIds[:]
+            lst.append(candidate)
+            lst.sort()
+            banLists.add(tuple(lst))
+    else:
+        for candidate in candidates:
+            lst = selectedIds[:]
+            lst.append(candidate)
+            nextIds = list(filter(lambda item: item != candidate, restIds))
+            dfs(idx+1, nextIds, banned_id, lst)
+
+
+def solution(user_id, banned_id):
+    dfs(0, user_id, banned_id, [])
+    global banLists
+    return len(banLists)


### PR DESCRIPTION
# 64064. 불량사용자

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/64064/)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
|        |             |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|             |           |

## 설계

재귀 dfs를 이용해 불량 사용자를 선택하고 선택된 사용자를 제외한 후 다음 불량사용자를 찾는 방식으로 풀었다.

1. 밴 아이디의 첫번째부터 dfs를 시작한다.
2. 현재 남아있는 아이디 목록에서 밴 아이디에 해당될 수 있는 id를 찾아 candidate list에 추가한다.
3. canidate 목록의 각각을 선택한 후 남은 아이디 목록과 선택된 아이디 목록을 다음  dfs로 넘겨준다.
4. 밴해야 할 아이디의 마지막 순서까지 왔다면 banList set에 추가한다.
5. dfs 가 종료되면 banList set의 갯수를 정답으로 반환한다.

### 시간복잡도

O(N^2)