### PR TITLE
junow/boj/9536 여우는 어떻게 울지

### DIFF
--- a/problems/boj/9536/junow.cpp
+++ b/problems/boj/9536/junow.cpp
@@ -1,0 +1,63 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int t;
+vector<string> a;
+string s, record;
+
+vector<string> split(string& s) {
+  istringstream ss(s);
+  string sb;
+  vector<string> ret;
+  while (getline(ss, sb, ' ')) {
+    ret.push_back(sb);
+  }
+  return ret;
+}
+
+string parse(string& s) {
+  int i = s.find("goes") + 5;
+  return s.substr(i);
+}
+
+bool check(string s) {
+  for (auto _s : a) {
+    if (_s == s) return false;
+  }
+  return true;
+}
+string getFox() {
+  vector<string> ss = split(record);
+  string fox = "";
+  for (auto s : ss) {
+    if (!check(s)) continue;
+    fox += s + " ";
+  }
+
+  return fox;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> t;
+
+  while (t--) {
+    a.clear();
+    record = "";
+
+    while (1) {
+      getline(cin, s);
+      if (s == "what does the fox say?") break;
+      if (record.size() == 0) {
+        record = s;
+      } else {
+        a.push_back(parse(s));
+      }
+    }
+    cout << getFox() << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# 9536. 여우는 어떻게 울지?

[문제링크](https://www.acmicpc.net/problem/9536)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Bronze I |   35.580%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    2184     |     0     |

## 설계

- 테스트케이스마다 초기화 주의
- 다른동물 울음소리 -> "goes" 시작점 + 5 에서 뒤로 다 짜른거
- 다른동물 울음소리를 동물 녹음소리에서 모두 빼준다.

### 시간복잡도

n 개의 울음소리마다 최대 100 글자를 검색해서 울음소리를 걸러냄
글자수 - n
울음소리 길이 - m

O(mn^2)

[findstd::string.find() 의 성능](https://rein.kr/blog/archives/373)

### 공간복잡도
