### PR TITLE
junow/boj/1764 듣보잡잡

### DIFF
--- a/problems/boj/1764/junow.cpp
+++ b/problems/boj/1764/junow.cpp
@@ -1,0 +1,33 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+int n, m;
+vector<string> a, ans;
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> n >> m;
+  string t;
+  a.resize(n);
+
+  for (int i = 0; i < n; i++) {
+    cin >> a[i];
+  }
+  sort(a.begin(), a.end());
+
+  for (int j = 0; j < m; j++) {
+    cin >> t;
+    if (binary_search(a.begin(), a.end(), t)) {
+      ans.push_back(t);
+    }
+  }
+
+  sort(ans.begin(), ans.end());
+
+  cout << ans.size() << "\n";
+  for (auto _s : ans) {
+    cout << _s << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# 1764. 듣보잡

[문제링크](https://www.acmicpc.net/problem/1764)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver IV |   38.741%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    5932     |    28     |

## 설계

듣도못한놈을 벡터에 넣어놓고
보도못한놈을 받으면서 듣도못한놈 안에 존재하면 듣도보도 못한놈

찾을때 binary_search 이용하면 빨라진다.

### 시간복잡도

O(NlogN)

### 공간복잡도
