### PR TITLE
bbumjun boj 2805 나무자르기

### DIFF
--- a/problems/boj/2805/bbumjun.py
+++ b/problems/boj/2805/bbumjun.py
@@ -1,0 +1,16 @@
+n, m = map(int, input().split())
+trees = list(map(int, input().split()))
+minH = 0
+maxH = max(trees)
+ans = 0
+while minH <= maxH:
+    cutH = (minH+maxH)//2
+    cutMount = 0
+    for tree in trees:
+        cutMount += (tree - cutH if tree >= cutH else 0)
+    if cutMount >= m:
+        ans = cutH
+        minH = cutH + 1
+    else:
+        maxH = cutH-1
+print(ans)


### PR DESCRIPTION
# 2805. 나무 자르기

[문제링크](https://www.acmicpc.net/problem/2805)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   25.911%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   242360    |    576    |

## 설계

자를 높이의 최솟값을 0, 최댓값을 전체 나무중 가장 긴 나무 길이로 잡고 이분탐색했다.

1. 매 싸이클마다 자를 높이의 중간값을 구하고, 각 나무마다 중간값을 빼 남는 나무 길이의 합을 구했다.

2. 필요한 나무의 길이보다 많거나 같으면 자른 높이를 정답에 저장하고, 최솟값을 중간값+1로 바꾼후 다시 이분탐색을 실행한다. 그렇지 않으면 최댓값을 중간값-1로 바꾼후 다시 이분탐색한다.

3. 최솟값이 최댓값과 같거나 커질 때까지 1~2를 반복한다.

   

### 시간복잡도

O(logN) 

나무를 자를 때 남는 나무 위치를 이분탐색해 자르는 로직으로 고치면 효율을 더 올릴 수 있을 것 같다.