### PR TITLE
junow/boj/2805 나무자르기

### DIFF
--- a/problems/boj/2805/junow.cpp
+++ b/problems/boj/2805/junow.cpp
@@ -1,0 +1,50 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+
+int N, M;
+vector<int> v(1000000);
+
+ll f(int h) {
+  ll ret = 0;
+  for (int i = 0; i < N; i++) {
+    if (v[i] > h) {
+      ret += (v[i] - h);
+    }
+  }
+  return ret;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  int maxh;
+  maxh = 0;
+
+  cin >> N >> M;
+  for (int i = 0; i < N; i++) {
+    cin >> v[i];
+    maxh = max(maxh, v[i]);
+  }
+
+  int l = 0;
+  int r = maxh;
+  int ans = 0;
+  while (l <= r) {
+    int m = (l + r) / 2;
+    ll t = f(m);
+    if (t < M) {
+      r = m - 1;
+    } else {
+      l = m + 1;
+    }
+  }
+
+  cout << r << "\n";
+  return 0;
+}


### PR DESCRIPTION
# 2805. 나무 자르기

[문제링크](https://www.acmicpc.net/problem/2805)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   25.913%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    5892     |    164    |

## 설계

결국 장막을 들추고 답을 봐버렸네요.
문제의 핵심은 무엇을 이분탐색하는지 같습니다. 처음엔 나무를 정렬해놓고 나무를 이분탐색해 나갔는데 시간초과에 걸렸습니다.

1. 이분탐색 하는 대상은 자르는 나무의 높이이다.
2. 0 ~ 최대 나무 높이 를 시작으로 탐색을 시작해서 중간값으로 나무를 잘라봤을떄 목표치보다 큰지 작은지 판단.
3. 이미 답을 찾은 경우에도 탐색을 끝까지하는 이유는 톱의 최대 높이를 찾아야하기 때문.

### 시간복잡도

O(logn \* n)
