### PR TITLE
junow/boj/1939 중량제한

### DIFF
--- a/problems/boj/1939/junow.cpp
+++ b/problems/boj/1939/junow.cpp
@@ -1,0 +1,68 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+
+int N, M, A, B, C, S, E, maxv;
+vector<vector<pii>> v;
+bool visit[10001];
+
+bool bfs(int m) {
+  queue<int> q;
+  fill(visit, visit + 10001, false);
+
+  q.push(S);
+
+  while (!q.empty()) {
+    auto cur = q.front();
+    q.pop();
+    if (cur == E) {
+      return true;
+    }
+
+    for (int i = 0, len = v[cur].size(); i < len; i++) {
+      auto next = v[cur][i];
+      if (visit[next.first]) continue;
+      if (next.second < m) continue;
+
+      visit[next.first] = true;
+      q.push(next.first);
+    }
+  }
+
+  return false;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> N >> M;
+  v.resize(N + 1);
+
+  for (int i = 0; i < M; i++) {
+    cin >> A >> B >> C;
+    v[A].push_back({B, C});
+    v[B].push_back({A, C});
+    maxv = max(maxv, C);
+  }
+
+  cin >> S >> E;
+  int l = 0, r = maxv;
+  int ans = 0;
+  while (l <= r) {
+    int m = (l + r) / 2;
+    if (bfs(m)) {
+      l = m + 1;
+      ans = max(ans, m);
+    } else {
+      r = m - 1;
+    }
+  }
+
+  cout << ans << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 1939. 중량제한
closes #53 

[문제링크](https://www.acmicpc.net/problem/1939)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold IV |   24.067%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    5516     |    48     |

## 설계

일반적인 bfs 처럼 돌립니다.
각 다리의 중량제한이 1e9 이기떄문에 중량제한을 이분탐색 했습니다.
mid 값에 대해서 bfs 를 돌려서 m 무게를 버틸 수 있는 다리들을 가쳐서 도착지에 도착하면 ok 입니다.

### 시간복잡도

bfs 에 대한 시간복잡도는 계산못하겠습니다.
이분탐색에는 logn 만큼 소요되니 logN \* bfs시간

bfs 는 최악의경우 한 정점에서 목적지 까지 도착하지 못할때 모든 정점쌍을 검사하면서 N^2 이 결릴 것 같습니다.
