### PR TITLE
bbumjun boj 2644 촌수계산

### DIFF
--- a/problems/boj/2644/bbumjun.py
+++ b/problems/boj/2644/bbumjun.py
@@ -1,0 +1,32 @@
+from collections import deque
+n = int(input())
+a, b = map(int, input().split())
+m = int(input())
+relation = {}
+for i in range(m):
+    parent, child = map(int, input().split())
+    relation.setdefault(parent, {})
+    relation.setdefault(child, {})
+    relation[parent].setdefault(child, {})
+    relation[child].setdefault(parent, {})
+ans = -1
+
+
+def bfs(x, y):
+    global relation, ans
+    isVisit = [False for _ in range(n+1)]
+    queue = deque([(x, 0)])
+    while len(queue) != 0:
+        cur, cost = queue.popleft()
+        if cur == y:
+            ans = cost
+            return
+        for child in relation[cur]:
+            if isVisit[child] == True or relation.get(child, 0) == 0:
+                continue
+            isVisit[child] = True
+            queue.append((child, cost+1))
+
+
+bfs(a, b)
+print(ans)


### PR DESCRIPTION
# 2644. 촌수계산

[문제링크](https://www.acmicpc.net/problem/2644)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver II |   45.508%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   122484    |    184    |

## 설계 

1.  친척관계를 dictionary를 사용해 그래프를 만들고
2. bfs로 한 친척에서 다른 친척에 도착할 때까지 거리를 더해주면서 탐색한다.

### 시간복잡도

O(N+M)