### PR TITLE
junow boj 2251 물통

### DIFF
--- a/problems/boj/2251/junow.cpp
+++ b/problems/boj/2251/junow.cpp
@@ -1,0 +1,68 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+vi a(3);
+bool visit[201][201][201];
+bool ans[201];
+
+void bfs() {
+  queue<vi> q;
+
+  vi init(3);
+  init[0] = 0;
+  init[1] = 0;
+  init[2] = a[2];
+
+  q.push(init);
+  visit[0][0][a[2]] = true;
+
+  while (!q.empty()) {
+    vi cur = q.front();
+    q.pop();
+
+    if (cur[0] == 0) {
+      ans[cur[2]] = true;
+    }
+
+    for (int i = 0; i < 3; i++) {
+      if (cur[i] == 0) continue;
+
+      for (int j = 0; j < 3; j++) {
+        if (i == j) continue;
+        if (cur[j] >= a[j]) continue;  // 할당량 초과
+        vi next;
+        next.resize(3, 0);
+        for (int k = 0; k < 3; k++) {
+          next[k] = cur[k];
+        }
+        int diff = min(next[i], a[j] - next[j]);
+        next[i] -= diff;
+        next[j] += diff;
+
+        if (visit[next[0]][next[1]][next[2]]) continue;
+        q.push(next);
+        visit[next[0]][next[1]][next[2]] = true;
+      }
+    }
+  }
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> a[0] >> a[1] >> a[2];
+
+  bfs();
+
+  for (int i = 0; i < 201; i++) {
+    if (ans[i]) cout << i << " ";
+  }
+  cout << "\n";
+
+  return 0;
+}


### PR DESCRIPTION
# 2251. 물통

[문제링크](https://www.acmicpc.net/problem/2251)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver I |   48.066%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    9920     |     0     |

## 설계

흔히 생각하는 bfs 식의 문제는 아니라서 bfs 문제인걸 몰랐으면 못풀었을것 같습니다.

일단 visit을 체크하는 변수는 200*200*200 짜리 3차원 배열을 이용했는데 다른사람들은 2차원으로도 해결하더군요.

각 상황에서 물통의 든 물 양을 queue 에 넣고 bfs 를 실행합니다. 2중 포문을 돌면서 물통[i] -> 물통[j] 로 옮겨줍니다.

여기서 옮겨가는 물의 양은 min(from, 할당량 - to) 입니다. 현재 물통이 빌때까지 물을 다 붓거나 새로운 물통이 다 찰때 까지 부을 수 있는 양을 계산하는 겁니다.

이부분은 잘못계산해서 1시간을 해맸는데 수치계산의 주의가 필요해보입니다.

### 시간복잡도

O(N^3) 같은데 잘 모르겠네요;
