### PR TITLE
junow boj 5567 결혼식

### DIFF
--- a/problems/boj/5567/junow.cpp
+++ b/problems/boj/5567/junow.cpp
@@ -1,0 +1,55 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef vector<vector<int>> vvi;
+typedef pair<int, int> pii;
+int N, M;
+bool visit[501];
+vvi a;
+
+int bfs() {
+  int ret = 0;
+  queue<int> q;
+  q.push(1);
+  visit[1] = true;
+  int depth = 0;
+
+  while (!q.empty()) {
+    int len = q.size();
+    for (int i = 0; i < len; i++) {
+      int cur = q.front();
+      q.pop();
+
+      for (int j = 0; j < a[cur].size(); j++) {
+        if (visit[a[cur][j]]) continue;
+        visit[a[cur][j]] = true;
+        q.push(a[cur][j]);
+        ret++;
+      }
+    }
+    depth++;
+    if (depth == 2) {
+      break;
+    }
+  }
+
+  return ret;
+}
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  int t1 = 0, t2 = 0;
+  cin >> N >> M;
+  a.resize(M + 1);
+  while (M--) {
+    cin >> t1 >> t2;
+    a[t1].push_back(t2);
+    a[t2].push_back(t1);
+  }
+
+  cout << bfs() << "\n";
+  return 0;
+}


### PR DESCRIPTION
# 5567 결혼식

[문제링크](https://www.acmicpc.net/problem/5567)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver I |   42.586%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    2484     |     0     |

## 설계

친구 관계를 벡터로 만들어둔다. 벡터로 만들어서 친구인 애들 번호를 push_back 으로 넣어두면 필요한 만큼만 공간을 쓸 수 있다.

bfs 를 실행하되 depth 가 2이상 가면 안된다.

1- 2

1- 3 - 4

2,3,4 총 3 명을 초대해야 하는데 각 depth 별로 현재 큐에 있는 친구들 수 만큼만 반복문을 돌면 찾아낼 수 있다.

두개의 반복문을 거치는데 첫번째 반복문을 queue 를 순회하기 위한, 두번째 반복문은 현재 친구의 친구들을 반복하는 반복문이다.

```c
while (!q.empty()) { // 전체 queue 반복
    int len = q.size();
    for (int i = 0; i < len; i++) {} // 현재 친구에 대해서 반복, 이 반복문이 끝나면 1 depth 완료한것.
}
```

### 시간복잡도

N 명에 친구에 대해 M 개의 관계만큼 봐야하니까
`O(N\*M)` ??
