### PR TITLE
bbumjun boj 2251 물통

### DIFF
--- a/problems/boj/2251/bbumjun.py
+++ b/problems/boj/2251/bbumjun.py
@@ -1,0 +1,34 @@
+from collections import deque
+from copy import deepcopy
+
+
+def moveWater(a, b):
+    emptySpace = b[1] - b[0]
+    if a[0] >= emptySpace:
+        b[0] = b[1]
+        a[0] -= emptySpace
+    else:
+        b[0] += a[0]
+        a[0] = 0
+
+
+a, b, c = map(int, input().split())
+ans = []
+isVisit = set([(0, 0, c)])
+q = deque([([0, a], [0, b], [c, c])])
+while len(q) != 0:
+    bottles = q.popleft()
+    if bottles[0][0] == 0:
+        ans.append(bottles[2][0])
+    for i in range(len(bottles)):
+        for j in range(len(bottles)):
+            if i == j or bottles[i][0] == 0:
+                continue
+            newBottles = deepcopy(bottles)
+            moveWater(newBottles[i], newBottles[j])
+            s = (newBottles[0][0], newBottles[1][0], newBottles[2][0])
+            if s in isVisit:
+                continue
+            isVisit.add(s)
+            q.append(deepcopy(newBottles))
+print(' '.join(map(str, sorted(ans))))


### PR DESCRIPTION
# 2251. 물통

[문제링크](https://www.acmicpc.net/problem/2251)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver I |   48.077%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   127400    |    308    |

## 설계

각 물통의 채워진 양을 tuple 로 묶어 방문여부를 따지며 bfs로 탐색했다.

2중 for문을 돌며 각 물통에서 다른 물통으로 옮겼을 때의 변화값을 계산하고, 변화한 물통의 양이 이전에 a,b,c에 그대로 담겼던 적이 있는지 체크 후  queue 에 push하는 방식으로 구현했다.  



### 시간복잡도

시간복잡도를 어떻게 계산해야할지 잘 모르겠네용..

