### PR TITLE
bbumjun  boj 14226 이모티콘

### DIFF
--- a/problems/boj/14226/bbumjun.py
+++ b/problems/boj/14226/bbumjun.py
@@ -1,0 +1,21 @@
+from collections import deque
+s = int(input())
+
+q = deque([(1, 0, 0)])
+ans = 0
+isVisit = set([1, 0])
+while len(q) != 0:
+    display, clipboard, cost = q.popleft()
+    if display == s:
+        ans = cost
+        break
+    if (display, display) not in isVisit:
+        isVisit.add((display, display))
+        q.append((display, display, cost+1))
+    if clipboard != 0 and (display+clipboard, clipboard) not in isVisit:
+        isVisit.add((display+clipboard, clipboard))
+        q.append((display+clipboard, clipboard, cost+1))
+    if display > 0 and (display-1, clipboard) not in isVisit:
+        isVisit.add((display-1, clipboard))
+        q.append((display-1, clipboard, cost+1))
+print(ans)


### PR DESCRIPTION
# 14226. 이모티콘

[문제링크](https://www.acmicpc.net/problem/14226)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| Gold V |   33.972%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   128132    |    204    |

## 설계

백준 물통 문제와 유형이 비슷한것 같다.

화면의 이모티콘 갯수, 클립보드의 이모티콘 갯수를 tuple로 묶어 방문여부를 판단한다.

bfs로 현재상태의 화면과 클립보드의 이모티콘 갯수, 걸린 시간을 tuple로 묶어 3가지 경우로 나뉘어 큐에 삽입한다.

1. 클립보드에 복사했을 때의 상태가 이전에 나온적 없을 때
2. 클립보드에 이모티콘이 1개이상이고 화면에 붙여넣은 상태가 이전에 나온적 없을 때
3. 화면의 이모티콘이 1개 이상이고 화면에서 이모티콘 1개를 지운 상태가 나온적 없을 때

가장 먼저 s개의 이모티콘을 만족했을때의 cost가 최소이므로 바로 while문을 탈출하고 출력한다.

### 시간복잡도

이런 로직에서 시간복잡도 계산하기가 난해하네요.. 잘 모르겠습니다 :cry:

