### PR TITLE
bbumjun boj 1707  이분그래프

### DIFF
--- a/problems/boj/1707/bbumjun.py
+++ b/problems/boj/1707/bbumjun.py
@@ -1,0 +1,39 @@
+from collections import deque
+
+
+def bfs(node, f):
+    global ans, graph, isVisit
+    q = deque([(node, f)])
+    isVisit[node] = (True, 1)
+    while len(q) != 0:
+        cur, flag = q.popleft()
+        for nxt in graph[cur]:
+            if isVisit[nxt][0] == True:
+                if isVisit[nxt][1] == flag:
+                    ans = 'NO'
+                    return
+            else:
+                isVisit[nxt] = (True, flag * -1)
+                q.append((nxt, flag*-1))
+
+
+tc = int(input())
+for _ in range(tc):
+    n, e = map(int, input().split())
+    graph = {}
+    for i in range(e):
+        a, b = map(int, input().split())
+        graph.setdefault(a, {})
+        graph.setdefault(b, {})
+        graph[a].setdefault(b, {})
+        graph[b].setdefault(a, {})
+    isVisit = [(False, 0) for _ in range(n+1)]
+    ans = 'YES'
+    for i in graph:
+        if isVisit[i][0] == True:
+            continue
+        bfs(i, 1)
+        if ans == 'NO':
+            break
+
+    print(ans)


### PR DESCRIPTION
# 1707. 이분그래프

[문제링크](https://www.acmicpc.net/problem/1707)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold IV |   22.811%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   226840    |   3156    |

## 설계

이분그래프에 대한 이해만 한다면 어렵지 않은 bfs 문제이다.

edge 로 이어져있는 모든 node 가 서로 다른 그룹이기만 하면 된다.

- 방문하지 않은 모든 node에 대해서 bfs로 순회한다.
- queue 는 node의 위치와 이전 node의 그룹의 상태를 1 또는 -1 로 가지고 있다.
- queue에서 pop한 node와 이어져있는 모든 edge를 순회하면서 방문한 적이 있다면 그룹번호를 확인하고, 같은 그룹번호를 가지고 있다면 NO를 저장하고 종료한다.
- 모든 노드에 대해 bfs를 마쳤다면 YES를 출력한다.

### 시간복잡도

O(V+E)