### PR TITLE
bbumjun boj 1039 교환

### DIFF
--- a/problems/boj/1039/bbumjun.py
+++ b/problems/boj/1039/bbumjun.py
@@ -1,0 +1,28 @@
+import queue
+n, k = map(int, input().split())
+n = list(str(n))
+res = -1
+q = queue.Queue()
+q.put((n, 0))
+isVisit = set([])
+depth = 0
+
+while q.empty() == False:
+    num, cnt = q.get()
+    if depth != cnt:
+        isVisit = set([])
+        depth = cnt
+    for i in range(len(num)-1):
+        for j in range(i+1, len(num)):
+            newNum = num[:]
+            newNum[i], newNum[j] = newNum[j], newNum[i]
+            numStr = ''.join(newNum)
+            if numStr[0] == '0':
+                continue
+            if cnt == k-1:
+                if res < int(numStr):
+                    res = int(numStr)
+            elif numStr not in isVisit:
+                isVisit.add(numStr)
+                q.put((newNum, cnt+1))
+print(res)


### PR DESCRIPTION
# 1039. 교환

[문제링크](https://www.acmicpc.net/problem/1039)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Gold III |   20.176%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|   130140    |    904    |

## 설계

bfs로 풀되, 수를 교환하는 각 단계를 넘어갈 때마다 visit set을 초기화해줘야 단계를 진행시킬 수 있다.

- 각 자릿수의 원활한 교환을 위해 숫자를 list 형태로 cnt와 함께 queue에 담는다.

- isVisit은 list대신 str형태로 저장해 체크한다.
- queue에서 pop한 node의 cnt를 확인해 depth가 1단계 깊어졌을 때마다 isVisit을 초기화한다.
- 2중 for 문을 돌면서 앞자리가 0이 될때를 제외하고 교환한 숫자를 queue에 push 한다.
- cnt 가 n-1일 때는 queue에 push하지 않고 정답을 갱신한다.

### 시간복잡도

`O(len(n)C2^2)`?