### PR TITLE
junow boj 15649 N 과 M(1)

### DIFF
--- a/problems/boj/15649/junow.cpp
+++ b/problems/boj/15649/junow.cpp
@@ -1,0 +1,42 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+int n, m, selected[9];
+bool visit[9];
+void dfs(int cnt) {
+  if (cnt == m) {
+    for (int i = 0; i < m; i++) {
+      cout << selected[i] << " ";
+    }
+    cout << endl;
+    return;
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (visit[i]) continue;
+    visit[i] = true;
+    selected[cnt] = i + 1;
+    dfs(cnt + 1);
+    visit[i] = false;
+  }
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> n >> m;
+
+  dfs(0);
+  return 0;
+}


### PR DESCRIPTION
# 15649. N과 M (1)

[문제링크](https://www.acmicpc.net/problem/15649)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   60.373%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |    28     |

## 설계

m 개 중 n 개를 뽑는 기본적인 수열 문제

cnt - 현재 골라야할 번호의 순서
각 단계마다 0 부터 n 까지중 하나를 뽑는데 이미 뽑았다면 (`visit[i] == true`) 뽑지 않는다.

m 개의 숫자를 뽑았다면 (`cnt == m`) 종료

### 시간복잡도

O(N!)
