### PR TITLE
junow boj 15651 n 과 m (3)

### DIFF
--- a/problems/boj/15651/junow.cpp
+++ b/problems/boj/15651/junow.cpp
@@ -1,0 +1,38 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+int n, m, selected[7];
+
+void dfs(int cnt) {
+  if (cnt == m) {
+    for (int i = 0; i < m; i++) {
+      cout << selected[i] << " ";
+    }
+    cout << endl;
+    return;
+  }
+
+  for (int i = 0; i < n; i++) {
+    selected[cnt] = i + 1;
+    dfs(cnt + 1);
+  }
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> n >> m;
+  dfs(0);
+
+  return 0;
+}


### PR DESCRIPTION
# 15651. N과 M (3)

[문제링크](https://www.acmicpc.net/problem/15651)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   66.272%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |    360    |

## 설계

1 부터 n 까지의 수 중 m 개를 중복 허용하고 모두 뽑는 문제이다.
재귀호출마다 1 부터 n 까지의 수를 모두 뽑는다.

출력 방식에 따라 시간 차이가 좀 나는듯 하다

배열에 넣고 하나씩 출력하는것 보다는 string 에 결과를 쌓아놓고 한번에 출력하면 더 빨리 나옴.

### 시간복잡도

O(N^M)
