### PR TITLE
junow boj 15652 n 과 m (4)

### DIFF
--- a/problems/boj/15652/junow.cpp
+++ b/problems/boj/15652/junow.cpp
@@ -1,0 +1,39 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+int n, m, selected[8];
+
+void dfs(int cnt, int idx) {
+  if (cnt == m) {
+    for (int i = 0; i < m; i++) {
+      cout << selected[i] << " ";
+    }
+    cout << endl;
+    return;
+  }
+
+  for (int i = idx; i < n; i++) {
+    selected[cnt] = i + 1;
+    dfs(cnt + 1, i);
+  }
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> n >> m;
+  dfs(0, 0);
+
+  return 0;
+}


### PR DESCRIPTION
# 15652. n 과 m (4)

[문제링크](https://www.acmicpc.net/problem/15652)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   82.585%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |     4     |

## 설계

1 부터 n 까지 m 개의 수를 뽑되 이전꺼 이상이기만 하면 된다.

재귀 함수 반복문의 시작값이 이전 단계에서 골랐던 수 이면 해결된다.

### 시간복잡도

O(N!)
