### PR TITLE
junow boj 1987 알파벳

### DIFF
--- a/problems/boj/1987/junow.cpp
+++ b/problems/boj/1987/junow.cpp
@@ -1,0 +1,52 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+int r, c, ans, visit;
+char board[20][20];
+
+bool isInRange(int y, int x) {
+  return min(y, x) >= 0 && y < r && x < c;
+}
+
+void bt(int y, int x, int depth) {
+  ans = max(ans, depth);
+
+  for (int dir = 0; dir < 4; dir++) {
+    int ny = y + dy[dir];
+    int nx = x + dx[dir];
+
+    if (!isInRange(ny, nx)) continue;
+    int next = board[ny][nx] - 64;
+    if (visit & (1 << next)) continue;
+
+    visit |= (1 << next);
+    bt(ny, nx, depth + 1);
+    visit &= ~(1 << next);
+  }
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> r >> c;
+  for (int i = 0; i < r; i++) {
+    cin >> board[i];
+  }
+  visit |= 1 << (board[0][0] - 64);
+  bt(0, 0, 0);
+
+  cout << ans + 1 << endl;
+
+  return 0;
+}


### PR DESCRIPTION
# 1987. 알파벳

[문제링크](https://www.acmicpc.net/problem/1987)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold IV |   30.506%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |    460    |

## 설계

입력이 작아서 최대 20 _ 20 _ 20 안에서 탐색이 이루어져서 시간초과는 안날 거 같음.

비트마스크로 방문 여부를 체크하는데 char - 'A' 는 0 이기 때문에 A 를 1 로 취급하기 위해서 board[i][j] - 64 만큼만 빼서 비트마스킹에 이용함.

### 시간복잡도

O(N^3)
