### PR TITLE
junow boj 1342 행운의 문자열

### DIFF
--- a/problems/boj/1342/junow.cpp
+++ b/problems/boj/1342/junow.cpp
@@ -1,0 +1,36 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+string s;
+int ans, cnt[26];
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> s;
+  int size = s.size();
+  do {
+    bool flag = true;
+    for (int i = 0; i < size - 1; i++) {
+      if (s[i] == s[i + 1]) {
+        flag = false;
+        break;
+      }
+    }
+    if (flag) ans++;
+  } while (next_permutation(s.begin(), s.end()));
+
+  cout << ans << endl;
+
+  return 0;
+}


### PR DESCRIPTION
# 1342. 행운의 문자열

closes #92 

[문제링크](https://www.acmicpc.net/problem/1342)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Gold III |   45.349%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1988     |    40     |

## 설계

- 첫번째 방법 - 모든 문자열 dfs 로 돌리면서 이전과 다른 문자를 부여하고 문자열 길이만큼 만들면 ans++;
- 두번째 방법 - 다른사람들은 그냥 `next_permutaion` 으로 모든경우 돌려서 나보다 6배나 빨리나와서 그냥 `next_permutaion` 으로 구현.

#### 첫번째 방법

```cpp
void dfs(int idx, int prev) {
  if (idx == s.size()) {
    ans++;
    return;
  }
  for (int i = 0; i < 26; i++) {
    if (!cnt[i]) continue;
    if (i == prev) continue;
    cnt[i]--;
    dfs(idx + 1, i);
    cnt[i]++;
  }
}
```

#### 두번째 방법

```cpp
  do {
    bool flag = true;
    for (int i = 0; i < size - 1; i++) {
      if (s[i] == s[i + 1]) {
        flag = false;
        break;
      }
    }
    if (flag) ans++;

  } while (next_permutation(s.begin(), s.end()));
```

첫번째 방법이 느린이유

1. 재귀호출

- 코드를 반복적으로 호출하는데 걸리는 시간이 있음.
- 결국 하는 행동은 `next_permutation` 과 똑같이 때문에 재귀호출로 잘 필요가 없음.

2. 쓸데없는 반복

- `next_permutaion` 으로 만든 문자열을 검사해보면 끝이지만 재귀호출에서는 모든 알파벳을 돌면서 여러가지 연산이 추가 됨.
  1. 남은 알파벳이 있는지 확인
  2. 이전과 다른지 확인
  3. 1,2 번 조건 통과하면 사용할 수 있는 알파벳 개수 줄이고 재귀 반복, 다시 알파벳 개수 늘리고

3. 그래도 6배씩이나 차이날 일인가 싶다.

### 시간복잡도

`next_permutaion` 의 시간복잡도는 `O(N)` , 각 순열마다 `N-1` 번의 비교,

O(N^2)
