### PR TITLE
junow 캐시

### DIFF
--- a/problems/programmers/17680/junow.cpp
+++ b/problems/programmers/17680/junow.cpp
@@ -1,0 +1,78 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+string toLower(string s) {
+  string ret = "";
+  for (auto& v : s) ret += tolower(v);
+  return ret;
+}
+
+bool checkCache(priority_queue<pair<int, string>> cache, string& city) {
+  while (!cache.empty()) {
+    auto cur = cache.top();
+    cache.pop();
+    if (cur.second == city) return true;
+  }
+
+  return false;
+}
+
+priority_queue<pair<int, string>> updateCache(priority_queue<pair<int, string>>& cache, string& city, int time) {
+  priority_queue<pair<int, string>> ret;
+
+  while (!cache.empty()) {
+    auto cur = cache.top();
+    cache.pop();
+    if (cur.second == city) {
+      ret.push({-time, city});
+    } else {
+      ret.push(cur);
+    }
+  }
+
+  return ret;
+}
+
+int solution(int cacheSize, vector<string> cities) {
+  int answer = 0;
+  priority_queue<pair<int, string>> cache;
+  for (auto& v : cities) v = toLower(v);
+
+  for (int i = 0, size = cities.size(); i < size; i++) {
+    if (checkCache(cache, cities[i])) {
+      answer++;
+      cache = updateCache(cache, cities[i], i);
+    } else {
+      if (!cache.empty() && cache.size() >= cacheSize) cache.pop();
+      if (cache.size() < cacheSize) cache.push({-i, cities[i]});
+      answer += 5;
+    }
+  }
+
+  return answer;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  int cacheSize1 = 3;
+  vector<string> cities1 = {"Jeju", "Pangyo", "Seoul", "NewYork", "LA", "Jeju", "Pangyo", "Seoul", "NewYork", "LA"};
+  int cacheSize2 = 3;
+  vector<string> cities2 = {"Jeju", "Pangyo", "Seoul", "Jeju", "Pangyo", "Seoul", "Jeju", "Pangyo", "Seoul"};
+  int cacheSize3 = 2;
+  vector<string> cities3 = {"Jeju", "Pangyo", "NewYork", "newyork"};
+  cout << solution(cacheSize2, cities2) << endl;
+
+  return 0;
+}


### PR DESCRIPTION
# 17680. 캐시

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/17680)

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|             |           |

## 설계

최대 도시수는 100,000 이기 때문에 `O(N^2)` 미만으로 풀도록 해보자.

도시수 : N,

캐시사이즈 : M

`LRU` 캐시는 가장 최근에 사용되지 않은 캐시를 교체하는 알고리즘이니까 `priority_queue` 로 구현하였다. `pair` 자료구조는 기본적으로 `first` 값 내림차순으로 구현 되기때문에 먼저 들어간 캐시를 `top` 에 두기 위해서는 캐시가 등록된 시간에 `-1` 을 곱하면 간단하게 구현할 수 있다.

모든 도시들을 한바퀴 순회하면서 캐시를 확인하고 있다면 `answer++`, 없다면 `answer+=5` 이다.

`cache miss` 가 났다면 새롭게 캐시를 등록해주어야 한다. 단순하게 `cache.pop()` 하면 가장 오래된 캐시를 지울 수 있다. 여기서 캐시사이즈를 체크해주어야함.

`cache hit` 가 났다면 새롭게 추가하지 않고 기존 캐시에 들은 시간값을 현재 시간으로 업데이트 해야한다. `priority_queue` 를 한바퀴 돌면서 `city` 값이 일치하는 캐시를 찾아야하기 때문에 `O(M)` 만큼의 시간이 들것이다.

`hit` 든 `miss` 든 cache 에 값을 삽입하는건 `log(M)` 이다. 전체 `cities` 수만큼 반복하면서 그안에서 `cache` 를 순회하면서 `hit` 판별, 그리고 `push` 혹은 `update` 를 하는데 이연산은 `O(M)` 그래서 전체 시간복잡도는 `O(NlogM)` 이다.

### 시간복잡도

`O(NlogM)`
