### PR TITLE
bbumjun 가장 먼 노드

### DIFF
--- a/problems/programmers/49189/bbumjun.py
+++ b/problems/programmers/49189/bbumjun.py
@@ -1,0 +1,30 @@
+import queue
+
+
+def bfs(n, graph):
+    q = queue.Queue()
+    isVisit = [False for _ in range(n+1)]
+    q.put((1, 0))
+    isVisit[1] = True
+    result = {}
+    while q.empty() != True:
+        cur, cost = q.get()
+        for nextNode in graph[cur]:
+            if isVisit[nextNode] == True:
+                continue
+            isVisit[nextNode] = True
+            result[cost+1] = result.get(cost+1, 0) + 1
+            q.put((nextNode, cost+1))
+    return result[cost]
+
+
+def solution(n, edge):
+    answer = 0
+    graph = {}
+    for e in edge:
+        graph.setdefault(e[0], [])
+        graph.setdefault(e[1], [])
+        graph[e[0]].append(e[1])
+        graph[e[1]].append(e[0])
+    answer = bfs(n, graph)
+    return answer


### PR DESCRIPTION
# 49189. 가장 먼 노느

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/49189)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
|        |             |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|             |           |

## 설계

bfs로 구현했다.

노드의 갯수가 크기 때문에 인접리스트로 구현했다.

`queue`는 `node` 의 위치와 현재까지의 거리를 가지고 모든 노드를 방문하고, 방문하지 않은 노드에 도착할 때 마다 걸린 `cost`의 갯수를 하나씩 더한다.

가장 큰 `cost`의 갯수를 정답으로 출력한다.





### 시간복잡도

`O(N*E)`